### PR TITLE
convert_temperature.json pt-BR translation

### DIFF
--- a/locales/convert_speed.json
+++ b/locales/convert_speed.json
@@ -178,5 +178,42 @@
             "description": "値を入力"
         },
         "translator_id": "1163416356566347828"
-    }
+    },
+    
+    "pt-BR": {
+        "name": {
+            "text": "converter_velocidade"
+        },
+        "command_desc": {
+            "text": "Um comando para converter velocidades para diferentes escalas"
+        },
+        "title": {
+            "text": "Velocidade:"
+        },
+        "unit_names": {
+            "miles": "Milhas:",
+            "kilometers": "Quilômetros:",
+            "meters": "Metros:",
+            "feet": "Pés:",
+            "megameters": "MegaMetros",
+            "light": "Constantes (Velocidade da Luz):"
+        },
+        "unit_symbols": {
+            "miles": "mi",
+            "kilometers": "km",
+            "meters": "m",
+            "feet": "ft",
+            "megameters": "Mm",
+            "light": "C"
+        },
+        "speed_unit": {
+            "name": "unidade_de_velocidade",
+            "description": "Selecione uma unidade de velocidade no menu abaixo."
+        },
+        "speed": {
+            "name": "velocidade",
+            "description": "Insira um número"
+        },
+        "translator_id": "1096865109541929161"
+    },
 }

--- a/locales/convert_temperature.json
+++ b/locales/convert_temperature.json
@@ -445,12 +445,12 @@
             "rankine": "°R"
         },
         "temperature_unit": {
-            "name": null,
-            "description": null
+            "name": "unidade_de_temperatura",
+            "description": "Selecione uma unidade de temperatura no menu abaixo"
         },
         "temperature": {
-            "name": null,
-            "description": null
+            "name": "temperatura",
+            "description": "Insira um número"
         },
         "translator_id": "1096865109541929161"
     },


### PR DESCRIPTION
t/n for "dropdown": it was translated into "menu abaixo" - lit. "table (of contents) below" - for the lack of a proper word. hope that's okay!