### PR TITLE
Fix: translate punctuation

### DIFF
--- a/locales/convert_speed.json
+++ b/locales/convert_speed.json
@@ -910,12 +910,12 @@
             "text": "速度："
         },
         "unit_names": {
-            "miles": "英里：",
-            "kilometers": "公里：",
-            "meters": "公尺：:",
-            "feet": "英尺：",
-            "megameters": "百萬米：",
-            "light": "光速："
+            "miles": "英里",
+            "kilometers": "公里",
+            "meters": "公尺",
+            "feet": "英尺",
+            "megameters": "百萬米",
+            "light": "光速"
         },
         "unit_symbols": {
             "miles": "mi",
@@ -946,9 +946,9 @@
             "text": "速度："
         },
         "unit_names": {
-            "miles": "英里：",
-            "kilometers": "公里：",
-            "meters": "公尺：:",
+            "miles": "英里",
+            "kilometers": "公里",
+            "meters": "公尺：",
             "feet": "英尺：",
             "megameters": "百萬米：",
             "light": "光速："

--- a/locales/convert_speed.json
+++ b/locales/convert_speed.json
@@ -948,10 +948,10 @@
         "unit_names": {
             "miles": "英里",
             "kilometers": "公里",
-            "meters": "公尺：",
-            "feet": "英尺：",
-            "megameters": "百萬米：",
-            "light": "光速："
+            "meters": "公尺",
+            "feet": "英尺",
+            "megameters": "百萬米",
+            "light": "光速"
         },
         "unit_symbols": {
             "miles": "mi",

--- a/locales/convert_temperature.json
+++ b/locales/convert_temperature.json
@@ -570,13 +570,13 @@
             "text": "温度："
         },
         "unit_names": {
-            "celsius": "摄氏度：",
-            "fahrenheit": "华氏度：",
-            "kelvin": "开氏度：",
-            "rankine": "兰氏度："
+            "celsius": "摄氏度",
+            "fahrenheit": "华氏度",
+            "kelvin": "开氏度",
+            "rankine": "兰氏度"
         },
         "desc": {
-            "text": "请选择："
+            "text": "选择："
         },
         "unit_symbols": {
             "celsius": "°C",
@@ -602,16 +602,16 @@
             "text": "一個轉換溫度到不同溫度單位的指令"
         },
         "title": {
-            "text": "溫度：:"
+            "text": "溫度："
         },
         "unit_names": {
-            "celsius": "攝氏度：",
-            "fahrenheit": "華氏度：",
-            "kelvin": "克耳文：",
-            "rankine": "蘭氏度："
+            "celsius": "攝氏度",
+            "fahrenheit": "華氏度",
+            "kelvin": "克耳文",
+            "rankine": "蘭氏度"
         },
         "desc": {
-            "text": "請選擇："
+            "text": "選擇："
         },
         "unit_symbols": {
             "celsius": "°C",


### PR DESCRIPTION
This PR modifies the punctuation in the translations to ensure consistency in the embed.

Before:
![image](https://github.com/user-attachments/assets/77f338a1-a2f7-4d13-818f-301dca5fd5b7)
After: 
![image](https://github.com/user-attachments/assets/5729cc83-4b00-4fbc-93b5-56bbf4e25266)
